### PR TITLE
[WIP] Rewrite b2 lmp

### DIFF
--- a/lammps/lammps_descriptor.cpp
+++ b/lammps/lammps_descriptor.cpp
@@ -202,13 +202,14 @@ void B2_descriptor(Eigen::VectorXd &B2_vals, Eigen::MatrixXd &B2_env_dervs,
                    double &norm_squared, Eigen::VectorXd &B2_env_dot,
                    const Eigen::VectorXd &single_bond_vals,
                    const Eigen::MatrixXd &single_bond_env_dervs, int n_species,
-                   int N, int lmax) {
+                   int N, int lmax, const Eigen::MatrixXd &beta_matrix, 
+                   Eigen::VectorXd &u, double *evdwl) {
 
   int env_derv_size = single_bond_env_dervs.rows();
   int neigh_size = env_derv_size / 3;
   int n_radial = n_species * N;
   int n_harmonics = (lmax + 1) * (lmax + 1);
-  int n_descriptors = (n_radial * (n_radial + 1)) * (lmax + 1);
+  int n_descriptors = (n_radial * (n_radial + 1) / 2) * (lmax + 1);
 
   int n1_l, n2_l, counter, n1_count, n2_count;
 
@@ -218,16 +219,14 @@ void B2_descriptor(Eigen::VectorXd &B2_vals, Eigen::MatrixXd &B2_env_dervs,
   B2_env_dot = Eigen::VectorXd::Zero(env_derv_size);
 
   // Compute the descriptor.
-  //for (int n1 = n_radial - 1; n1 >= 0; n1--) {
-  counter = 0;
-  for (int n1 = 0; n1 < n_radial; n1++) {
-//    n1_count = (n1 * (2 * n_radial - n1 + 1)) / 2;
+  for (int n1 = n_radial - 1; n1 >= 0; n1--) {
+    n1_count = (n1 * (2 * n_radial - n1 + 1)) / 2;
 
-    for (int n2 = 0; n2 < n_radial; n2++) {
-//      n2_count = n2 - n1;
+    for (int n2 = n1; n2 < n_radial; n2++) {
+      n2_count = n2 - n1;
 
       for (int l = 0; l < (lmax + 1); l++) {
-//        counter = l + (n1_count + n2_count) * (lmax + 1);
+        counter = l + (n1_count + n2_count) * (lmax + 1);
 
         for (int m = 0; m < (2 * l + 1); m++) {
           n1_l = n1 * n_harmonics + (l * l + m);
@@ -235,24 +234,47 @@ void B2_descriptor(Eigen::VectorXd &B2_vals, Eigen::MatrixXd &B2_env_dervs,
 
           // Store B2 value.
           B2_vals(counter) += single_bond_vals(n1_l) * single_bond_vals(n2_l);
-
-          // Store environment force derivatives.
-          for (int atom_index = 0; atom_index < neigh_size; atom_index++) {
-            for (int comp = 0; comp < 3; comp++) {
-              B2_env_dervs(atom_index * 3 + comp, counter) +=
-                  single_bond_vals(n1_l) *
-                      single_bond_env_dervs(atom_index * 3 + comp, n2_l) +
-                  single_bond_env_dervs(atom_index * 3 + comp, n1_l) *
-                      single_bond_vals(n2_l);
-            }
-          }
         }
-        counter++;
       }
     }
   }
 
-  // Compute descriptor norm and dot products.
+  // Compute w(n1, n2, l), where f_ik = w * dB/dr_ik
   norm_squared = B2_vals.dot(B2_vals);
-  B2_env_dot = B2_env_dervs * B2_vals;
+  Eigen::VectorXd beta_p = beta_matrix * B2_vals;
+  *evdwl = B2_vals * beta_p / B2_norm_squared;
+  Eigen::VectorXd w = 2 * (beta_p - evdwl * B2_vals) / norm_squared; 
+
+  // Compute u(n1, l, m), where f_ik = u * dA/dr_ik
+  u = Eigen::VectorXd::Zero(single_bond_vals.size());
+  double factor;
+  for (int n1 = n_radial - 1; n1 >= 0; n1--) {
+    for (int n2 = 0; n2 < n_radial; n2++) {
+      if (n1 == n2){
+        n1_count = (n1 * (2 * n_radial - n1 + 1)) / 2;
+        n2_count = n2 - n1;
+        factor = 1.0;
+      } else if (n1 < n2) {
+        n1_count = (n1 * (2 * n_radial - n1 + 1)) / 2;
+        n2_count = n2 - n1;
+        factor = 0.5;
+      } else {
+        n1_count = (n2 * (2 * n_radial - n2 + 1)) / 2;
+        n2_count = n1 - n2;
+        factor = 0.5;
+      }
+
+      for (int l = 0; l < (lmax + 1); l++) {
+        counter = l + (n1_count + n2_count) * (lmax + 1);
+
+        for (int m = 0; m < (2 * l + 1); m++) {
+          n1_l = n1 * n_harmonics + (l * l + m);
+          n2_l = n2 * n_harmonics + (l * l + m);
+
+          u(n1_l) += w(counter) * single_bond_vals(n2_l) * factor;
+        }
+      }
+    }
+  }
+  u *= 2;
 }

--- a/lammps/lammps_descriptor.cpp
+++ b/lammps/lammps_descriptor.cpp
@@ -208,7 +208,7 @@ void B2_descriptor(Eigen::VectorXd &B2_vals, Eigen::MatrixXd &B2_env_dervs,
   int neigh_size = env_derv_size / 3;
   int n_radial = n_species * N;
   int n_harmonics = (lmax + 1) * (lmax + 1);
-  int n_descriptors = (n_radial * (n_radial + 1) / 2) * (lmax + 1);
+  int n_descriptors = (n_radial * (n_radial + 1)) * (lmax + 1);
 
   int n1_l, n2_l, counter, n1_count, n2_count;
 
@@ -218,14 +218,16 @@ void B2_descriptor(Eigen::VectorXd &B2_vals, Eigen::MatrixXd &B2_env_dervs,
   B2_env_dot = Eigen::VectorXd::Zero(env_derv_size);
 
   // Compute the descriptor.
-  for (int n1 = n_radial - 1; n1 >= 0; n1--) {
-    n1_count = (n1 * (2 * n_radial - n1 + 1)) / 2;
+  //for (int n1 = n_radial - 1; n1 >= 0; n1--) {
+  counter = 0;
+  for (int n1 = 0; n1 < n_radial; n1++) {
+//    n1_count = (n1 * (2 * n_radial - n1 + 1)) / 2;
 
-    for (int n2 = n1; n2 < n_radial; n2++) {
-      n2_count = n2 - n1;
+    for (int n2 = 0; n2 < n_radial; n2++) {
+//      n2_count = n2 - n1;
 
       for (int l = 0; l < (lmax + 1); l++) {
-        counter = l + (n1_count + n2_count) * (lmax + 1);
+//        counter = l + (n1_count + n2_count) * (lmax + 1);
 
         for (int m = 0; m < (2 * l + 1); m++) {
           n1_l = n1 * n_harmonics + (l * l + m);
@@ -245,6 +247,7 @@ void B2_descriptor(Eigen::VectorXd &B2_vals, Eigen::MatrixXd &B2_env_dervs,
             }
           }
         }
+        counter++;
       }
     }
   }

--- a/lammps/lammps_descriptor.h
+++ b/lammps/lammps_descriptor.h
@@ -39,6 +39,7 @@ void B2_descriptor(Eigen::VectorXd &B2_vals, Eigen::MatrixXd &B2_env_dervs,
                    double &norm_squared, Eigen::VectorXd &B2_env_dot,
                    const Eigen::VectorXd &single_bond_vals,
                    const Eigen::MatrixXd &single_bond_env_dervs, int n_species,
-                   int N, int lmax);
+                   int N, int lmax, const Eigen::MatrixXd &beta_matrix
+                   Eigen::VectorXd &u, double *evdwl);
 
 #endif

--- a/lammps/pair_flare.cpp
+++ b/lammps/pair_flare.cpp
@@ -88,7 +88,7 @@ void PairFLARE::compute(int eflag, int vflag) {
 
   int beta_init, beta_counter;
   double B2_norm_squared, B2_val_1, B2_val_2;
-  Eigen::VectorXd single_bond_vals, B2_vals, B2_env_dot, beta_p, partial_forces;
+  Eigen::VectorXd single_bond_vals, B2_vals, B2_env_dot, u;
   Eigen::MatrixXd single_bond_env_dervs, B2_env_dervs;
   double empty_thresh = 1e-8;
 
@@ -131,25 +131,14 @@ void PairFLARE::compute(int eflag, int vflag) {
     // Compute invariant descriptors.
     B2_descriptor(B2_vals, B2_env_dervs, B2_norm_squared, B2_env_dot,
                   single_bond_vals, single_bond_env_dervs, n_species, n_max,
-                  l_max);
+                  l_max, beta_matrices[itype - 1], u, &evdwl);
     timestamp_t t2 = get_timestamp();
     secs = (t2 - t1) / 1000000.0L;
     std::cout << "b2_desc " << secs << std::endl;
 
-
     // Continue if the environment is empty.
     if (B2_norm_squared < empty_thresh)
       continue;
-
-    // Compute local energy and partial forces.
-    beta_p = beta_matrices[itype - 1] * B2_vals;
-    evdwl = B2_vals.dot(beta_p) / B2_norm_squared;
-    partial_forces =
-        2 * (-B2_env_dervs * beta_p + evdwl * B2_env_dot) / B2_norm_squared;
-    timestamp_t t3 = get_timestamp();
-    secs = (t3 - t2) / 1000000.0L;
-    std::cout << "innerprod " << secs << std::endl;
-
 
     // Update energy, force and stress arrays.
     n_count = 0;
@@ -163,9 +152,15 @@ void PairFLARE::compute(int eflag, int vflag) {
       rsq = delx * delx + dely * dely + delz * delz;
 
       if (rsq < (cutoff_val * cutoff_val)) {
-        double fx = -partial_forces(n_count * 3);
-        double fy = -partial_forces(n_count * 3 + 1);
-        double fz = -partial_forces(n_count * 3 + 2);
+        // Compute partial force f_ij = u * dA/dr_ij
+        double fx = single_bond_env_dervs.row(n_count * 3).dot(u);
+        double fy = single_bond_env_dervs.row(n_count * 3 + 1).dot(u);
+        double fz = single_bond_env_dervs.row(n_count * 3 + 2).dot(u);
+        // Compute local energy and partial forces.
+        timestamp_t t3 = get_timestamp();
+        secs = (t3 - t2) / 1000000.0L;
+        std::cout << "innerprod " << secs << std::endl;
+
         f[i][0] += fx;
         f[i][1] += fy;
         f[i][2] += fz;
@@ -328,7 +323,7 @@ void PairFLARE::read_file(char *filename) {
 
   // Set number of descriptors.
   int n_radial = n_max * n_species;
-  n_descriptors = (n_radial * (n_radial + 1)) * (l_max + 1);
+  n_descriptors = (n_radial * (n_radial + 1) / 2) * (l_max + 1);
 
   // Check the relationship between the power spectrum and beta.
   int beta_check = n_descriptors * (n_descriptors + 1) / 2;

--- a/src/flare_pp/descriptors/b2.cpp
+++ b/src/flare_pp/descriptors/b2.cpp
@@ -192,7 +192,7 @@ void compute_b2(Eigen::MatrixXd &B2_vals, Eigen::MatrixXd &B2_force_dervs,
   int n_radial = nos * N;
   int n_harmonics = (lmax + 1) * (lmax + 1);
   int n_bond = n_radial * n_harmonics;
-  int n_d = (n_radial * (n_radial + 1)) * (lmax + 1);
+  int n_d = (n_radial * (n_radial + 1) / 2) * (lmax + 1);
 
   // Initialize arrays.
   B2_vals = Eigen::MatrixXd::Zero(n_atoms, n_d);
@@ -207,7 +207,7 @@ void compute_b2(Eigen::MatrixXd &B2_vals, Eigen::MatrixXd &B2_force_dervs,
     int n1, n2, l, m, n1_l, n2_l;
     int counter = 0;
     for (int n1 = 0; n1 < n_radial; n1++) {
-      for (int n2 = 0; n2 < n_radial; n2++) { // can be simplified
+      for (int n2 = n1; n2 < n_radial; n2++) { // can be simplified
         for (int l = 0; l < (lmax + 1); l++) {
           for (int m = 0; m < (2 * l + 1); m++) {
             n1_l = n1 * n_harmonics + (l * l + m);

--- a/src/flare_pp/descriptors/b2.cpp
+++ b/src/flare_pp/descriptors/b2.cpp
@@ -192,7 +192,7 @@ void compute_b2(Eigen::MatrixXd &B2_vals, Eigen::MatrixXd &B2_force_dervs,
   int n_radial = nos * N;
   int n_harmonics = (lmax + 1) * (lmax + 1);
   int n_bond = n_radial * n_harmonics;
-  int n_d = (n_radial * (n_radial + 1) / 2) * (lmax + 1);
+  int n_d = (n_radial * (n_radial + 1)) * (lmax + 1);
 
   // Initialize arrays.
   B2_vals = Eigen::MatrixXd::Zero(n_atoms, n_d);
@@ -207,7 +207,7 @@ void compute_b2(Eigen::MatrixXd &B2_vals, Eigen::MatrixXd &B2_force_dervs,
     int n1, n2, l, m, n1_l, n2_l;
     int counter = 0;
     for (int n1 = 0; n1 < n_radial; n1++) {
-      for (int n2 = n1; n2 < n_radial; n2++) {
+      for (int n2 = 0; n2 < n_radial; n2++) { // can be simplified
         for (int l = 0; l < (lmax + 1); l++) {
           for (int m = 0; m < (2 * l + 1); m++) {
             n1_l = n1 * n_harmonics + (l * l + m);


### PR DESCRIPTION
The pair style with summation order reorganized. Now has passed unit test.
Some timing results with SiC:
- Our previous implementation (unit: s)
```python
function single_bond [time=1.76481]

function B2_descriptor [time=13.68479]
    for n1, n2, l, m 
        B(n1, n2, l) += A(n1, l, m) * A(n2, l, m)  
        for neigh_k
             dB(n1, n2, l)/dr_ik

beta_matrix * B (matrix-vector multiplication) [time=6.23888]

[total time=21.68848]
```

- This PR (with more details below)
```python
function single_bond [time=1.636844]

function B2_descriptor [time=7.245533]
    for n, l, m
	A(n,l,m)
	for neigh_k
		dA(n,l,m) / dr_ik

    for n1, n2, l, m
	B(n1,n2,l) += A(n1,l,m) * A(n2,l,m)

    w = beta_matrix * B (matrix-vector multiplication)

    for n1, n2, l, m
	u(n1,l,m) += w(n1,n2,l) * A(n2,l,m)

compute partial forces [time=1.807217]
    for n1, l, m, neigh_k // In practice the loop is only a matrix-vector multiplication u * dA
	f_ik += 2 * u(n1,l,m) * dA(n1,l,m) / dr_ik

[total time=10.689594]
```

TODO:
- [ ] Fix variance `compute` command with the new B2_descriptor function
- [ ] remove time stamps in pair style