### PR TITLE
Remove numpy / scipy redundancy and add pybind11 to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-numpy>=1.16.0
 cmake>=3.14.5
 mir-flare
-scipy
+pybind11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 cmake>=3.14.5
 mir-flare
-pybind11


### PR DESCRIPTION
Add pybind11 to requirements.txt, which is used in compilation / installation / accessing C++ objects. I had difficulty compiling this without pybind11 being installed. Additionally, unless there is a reason I'm missing,[ scipy and numpy are included in the requirements for `mir-flare`](https://github.com/mir-group/flare/blob/master/requirements.txt) and should be able to be safely removed from this requirements.txt since the dependency is handled implicitly.