### PR TITLE
add deepcopy to mean_efs to prevent memory accumulation

### DIFF
--- a/flare_pp/sparse_gp_calculator.py
+++ b/flare_pp/sparse_gp_calculator.py
@@ -4,7 +4,7 @@ from flare_pp._C_flare import Structure
 from flare_pp.sparse_gp import SGP_Wrapper
 import numpy as np
 import time, json
-
+from copy import deepcopy
 
 class SGP_Calculator(Calculator):
 
@@ -54,11 +54,11 @@ class SGP_Calculator(Calculator):
             self.gp_model.sparse_gp.predict_local_uncertainties(structure_descriptor)
 
         # Set results.
-        self.results["energy"] = structure_descriptor.mean_efs[0]
-        self.results["forces"] = structure_descriptor.mean_efs[1:-6].reshape(-1, 3)
+        self.results["energy"] = deepcopy(structure_descriptor.mean_efs[0])
+        self.results["forces"] = deepcopy(structure_descriptor.mean_efs[1:-6].reshape(-1, 3))
 
         # Convert stress to ASE format.
-        flare_stress = structure_descriptor.mean_efs[-6:]
+        flare_stress = deepcopy(structure_descriptor.mean_efs[-6:])
         ase_stress = -np.array(
             [
                 flare_stress[0],


### PR DESCRIPTION
Bug: When calling `sparse_gp_calculator`, in the `calculate` function when the `mean_efs` is stored into `self.results`, the pointer to `structure_descriptors` seems to be kept, and is not destroyed when the `gp_calc` is altered. Then the memory of the descriptors (and derivatives) is not released, and is accumulated until blowing up.

Fix: the solution is to save the `deepcopy` of `mean_efs` to `self.results`.