### PR TITLE
Fix lammps variance for isolated atoms

### DIFF
--- a/flare_pp/sparse_gp.py
+++ b/flare_pp/sparse_gp.py
@@ -355,7 +355,7 @@ class SGP_Wrapper:
                     "The custom_range should be set as [n_added] if mode='uncertain'"
                 )
         elif mode == "specific":
-            if not custom_range:
+            if len(custom_range) == 0:
                 warnings.warn(
                     "The mode='specific' but no custom_range is given, will not add sparse envs"
                 )
@@ -483,7 +483,7 @@ class SGP_Wrapper:
         # add training data
         sparse_indices = self.sparse_gp.sparse_indices
         assert len(sparse_indices) == len(kernels)
-        assert len(sparse_indices[0]) == len(self.training_data)
+        assert len(sparse_indices[0]) == len(self.training_data), (len(sparse_indices[0]), len(self.training_data))
 
         for s in range(len(self.training_data)):
             custom_range = sparse_indices[0][s]

--- a/lammps_plugins/compute_flare_std_atom.cpp
+++ b/lammps_plugins/compute_flare_std_atom.cpp
@@ -130,6 +130,7 @@ void ComputeFlareStdAtom::compute_peratom() {
 
   Eigen::VectorXd single_bond_vals, B2_vals, B2_env_dot, beta_p, partial_forces, u;
   Eigen::MatrixXd single_bond_env_dervs, B2_env_dervs;
+  double empty_thresh = 1e-8;
 
   for (ii = 0; ii < ntotal; ii++) {
     stds[ii] = 0.0;
@@ -172,9 +173,14 @@ void ComputeFlareStdAtom::compute_peratom() {
     B2_descriptor(B2_vals, B2_norm_squared,
                   single_bond_vals, n_species, n_max, l_max);
 
-    double variance;
+    double variance = 0.0;
     double sig = hyperparameters(0);
     double sig2 = sig * sig;
+
+    // Continue if the environment is empty.
+    if (B2_norm_squared < empty_thresh)
+      continue;
+
     if (use_map) {
       int power = 2;
       compute_energy_and_u(B2_vals, B2_norm_squared, single_bond_vals, power,
@@ -200,7 +206,7 @@ void ComputeFlareStdAtom::compute_peratom() {
     }
 
     // Compute the normalized variance, it could be negative
-    if (variance > 0.0) {
+    if (variance >= 0.0) {
       stds[i] = pow(variance, 0.5); 
     } else {
       stds[i] = - pow(abs(variance), 0.5); 

--- a/src/flare_pp/bffs/sparse_gp.cpp
+++ b/src/flare_pp/bffs/sparse_gp.cpp
@@ -1345,6 +1345,9 @@ void SparseGP::write_L_inverse(
 
 void SparseGP::write_sparse_descriptors(
   std::string file_name, std::string contributor) {
+  
+  double empty_thresh = 1e-8;
+
   // Make beta file.
   std::ofstream coeff_file;
   coeff_file.open(file_name);
@@ -1382,7 +1385,11 @@ void SparseGP::write_sparse_descriptors(
       coeff_file << n_clusters_by_type << "\n";
       for (int j = 0; j < n_clusters_by_type; j++) {
         for (int k = 0; k < n_descriptors; k++) {
-          coeff_file << sparse_descriptors[i].descriptors[s](j, k) / sparse_descriptors[i].descriptor_norms[s](j) << " "; 
+          if (sparse_descriptors[i].descriptor_norms[s](j) < empty_thresh) {
+            coeff_file << 0.0 << " ";
+          } else {
+            coeff_file << sparse_descriptors[i].descriptors[s](j, k) / sparse_descriptors[i].descriptor_norms[s](j) << " "; 
+          }
 
           // Change line after writing 5 numbers
           if (count % 5 == 0) coeff_file << "\n";

--- a/src/flare_pp/descriptors/b2.cpp
+++ b/src/flare_pp/descriptors/b2.cpp
@@ -233,9 +233,11 @@ void compute_b2(Eigen::MatrixXd &B2_vals, Eigen::MatrixXd &B2_force_dervs,
     }
     // Compute descriptor norm and force dot products.
     B2_norms(atom) = sqrt(B2_vals.row(atom).dot(B2_vals.row(atom)));
-    B2_force_dots.segment(force_start, n_atom_neighbors * 3) =
-        B2_force_dervs.block(force_start, 0, n_atom_neighbors * 3, n_d) *
-        B2_vals.row(atom).transpose();
+    if (n_atom_neighbors > 0) {
+      B2_force_dots.segment(force_start, n_atom_neighbors * 3) =
+          B2_force_dervs.block(force_start, 0, n_atom_neighbors * 3, n_d) *
+          B2_vals.row(atom).transpose();
+    }
   }
 }
 

--- a/tests/get_sgp.py
+++ b/tests/get_sgp.py
@@ -44,6 +44,22 @@ def get_random_atoms(a=2.0, sc_size=2, numbers=[6, 8],
     return flare_atoms
 
 
+def get_isolated_atoms(number):
+
+    """Create a random structure."""
+
+    a = 20.0
+    cell = np.eye(3) * a
+    numbers = [number]
+    positions = np.array([[0, 0, 0]])
+    unit_cell = Atoms(cell=cell, positions=positions, numbers=numbers,
+                      pbc=True)
+    atoms = unit_cell
+    flare_atoms = FLARE_Atoms.from_ase_atoms(atoms)
+
+    return flare_atoms
+
+
 def get_empty_sgp(n_types=2, power=2, multiple_cutoff=False):
     kernel.power = power
 
@@ -57,7 +73,7 @@ def get_empty_sgp(n_types=2, power=2, multiple_cutoff=False):
     if multiple_cutoff:
         cutoff_matrix += np.eye(n_types) - 1
 
-    descriptor_settings = [n_types, 8, 3]
+    descriptor_settings = [n_types, 3, 2]
     b2_calc = B2(radial_basis, cutoff_function, radial_hyps, cutoff_hyps,
                  descriptor_settings, cutoff_matrix)
 
@@ -76,6 +92,9 @@ def get_updated_sgp(n_types=2, power=2, multiple_cutoff=False):
     elif n_types == 2:
         numbers = [6, 8]
 
+    sgp = get_empty_sgp(n_types, power, multiple_cutoff)
+
+    # add a random structure to the training set
     training_structure = get_random_atoms(numbers=numbers)
     training_structure.calc = LennardJones()
 
@@ -83,9 +102,21 @@ def get_updated_sgp(n_types=2, power=2, multiple_cutoff=False):
     energy = training_structure.get_potential_energy()
     stress = training_structure.get_stress()
 
-    sgp = get_empty_sgp(n_types, power, multiple_cutoff)
     sgp.update_db(training_structure, forces, custom_range=(1, 2, 3, 4, 5),
                   energy=energy, stress=stress, mode="specific")
+
+    # add an isolated atom to the training data
+    training_structure = get_isolated_atoms(number=6)
+    training_structure.calc = LennardJones()
+
+    forces = training_structure.get_forces()
+    energy = training_structure.get_potential_energy()
+    stress = training_structure.get_stress()
+
+    sgp.update_db(training_structure, forces, custom_range=(0,),
+                  energy=energy, stress=stress, mode="specific")
+
+    print("sparse_indices", sgp.sparse_gp.sparse_indices)
 
     return sgp
 

--- a/tests/get_sgp.py
+++ b/tests/get_sgp.py
@@ -44,14 +44,13 @@ def get_random_atoms(a=2.0, sc_size=2, numbers=[6, 8],
     return flare_atoms
 
 
-def get_isolated_atoms(number):
+def get_isolated_atoms(numbers=[6, 8]):
 
     """Create a random structure."""
 
-    a = 20.0
+    a = 30.0
     cell = np.eye(3) * a
-    numbers = [number]
-    positions = np.array([[0, 0, 0]])
+    positions = np.array([[0, 0, 0], [a/2, a/2, a/2]])
     unit_cell = Atoms(cell=cell, positions=positions, numbers=numbers,
                       pbc=True)
     atoms = unit_cell
@@ -106,7 +105,7 @@ def get_updated_sgp(n_types=2, power=2, multiple_cutoff=False):
                   energy=energy, stress=stress, mode="specific")
 
     # add an isolated atom to the training data
-    training_structure = get_isolated_atoms(number=6)
+    training_structure = get_isolated_atoms(numbers=numbers)
     training_structure.calc = LennardJones()
 
     forces = training_structure.get_forces()

--- a/tests/test_lammps.py
+++ b/tests/test_lammps.py
@@ -11,6 +11,7 @@ from .get_sgp import get_sgp_calc, get_random_atoms, get_isolated_atoms
 n_species_list = [1, 2]
 n_desc_types = [1, 2]
 power_list = [1, 2]
+struc_list = ["random", "isolated"]
 rootdir = os.getcwd()
 
 @pytest.mark.skipif(
@@ -23,8 +24,9 @@ rootdir = os.getcwd()
 @pytest.mark.parametrize("n_species", n_species_list)
 @pytest.mark.parametrize("n_types", n_desc_types)
 @pytest.mark.parametrize("power", power_list)
+@pytest.mark.parametrize("struc", struc_list)
 @pytest.mark.parametrize("multicut", [False, True])
-def test_write_potential(n_species, n_types, power, multicut):
+def test_write_potential(n_species, n_types, power, struc, multicut):
     """Test the flare_pp pair style."""
 
     if n_species > n_types:
@@ -48,7 +50,11 @@ def test_write_potential(n_species, n_types, power, multicut):
     elif n_species == 2:
         numbers = [6, 8]
         species = ["C", "O"]
-    test_structure = get_random_atoms(a=1.0, sc_size=2, numbers=numbers)
+
+    if struc == "random":
+        test_structure = get_random_atoms(a=2.0, sc_size=2, numbers=numbers)
+    elif struc == "isolated":
+        test_structure = get_isolated_atoms(numbers=numbers)
     test_structure.calc = sgp_model
 
     # Predict with SGP.
@@ -106,8 +112,9 @@ def test_write_potential(n_species, n_types, power, multicut):
 @pytest.mark.parametrize("n_types", n_desc_types)
 @pytest.mark.parametrize("use_map", [False, True])
 @pytest.mark.parametrize("power", power_list)
+@pytest.mark.parametrize("struc", struc_list)
 @pytest.mark.parametrize("multicut", [False, True])
-def test_lammps_uncertainty(n_species, n_types, use_map, power, multicut):
+def test_lammps_uncertainty(n_species, n_types, use_map, power, struc, multicut):
     if n_species > n_types:
         pytest.skip()
 
@@ -150,7 +157,11 @@ def test_lammps_uncertainty(n_species, n_types, use_map, power, multicut):
         numbers = [6, 8]
         species = ["C", "O"]
         mass_str = "mass 1 12\nmass 2 16"
-    test_atoms = get_random_atoms(a=3.0, sc_size=2, numbers=numbers)
+
+    if struc == "random":
+        test_atoms = get_random_atoms(a=3.0, sc_size=2, numbers=numbers)
+    elif struc == "isolated":
+        test_atoms = get_isolated_atoms(numbers=numbers)
 
     # compute uncertainty 
     in_lmp = f"""

--- a/tests/test_lammps.py
+++ b/tests/test_lammps.py
@@ -6,7 +6,7 @@ from flare.ase.atoms import FLARE_Atoms
 from ase.calculators.lammpsrun import LAMMPS
 from ase.io import read, write
 
-from .get_sgp import get_sgp_calc, get_random_atoms
+from .get_sgp import get_sgp_calc, get_random_atoms, get_isolated_atoms
 
 n_species_list = [1, 2]
 n_desc_types = [1, 2]
@@ -48,7 +48,7 @@ def test_write_potential(n_species, n_types, power, multicut):
     elif n_species == 2:
         numbers = [6, 8]
         species = ["C", "O"]
-    test_structure = get_random_atoms(a=2.0, sc_size=2, numbers=numbers)
+    test_structure = get_random_atoms(a=1.0, sc_size=2, numbers=numbers)
     test_structure.calc = sgp_model
 
     # Predict with SGP.
@@ -150,7 +150,7 @@ def test_lammps_uncertainty(n_species, n_types, use_map, power, multicut):
         numbers = [6, 8]
         species = ["C", "O"]
         mass_str = "mass 1 12\nmass 2 16"
-    test_atoms = get_random_atoms(a=2.0, sc_size=2, numbers=numbers)
+    test_atoms = get_random_atoms(a=3.0, sc_size=2, numbers=numbers)
 
     # compute uncertainty 
     in_lmp = f"""
@@ -202,6 +202,7 @@ run 0
     sgp_stds = test_atoms.calc.get_uncertainties(test_atoms)
     print(sgp_stds)
     print(lmp_stds)
+    print(sgp_model.gp_model.hyps)
     assert np.allclose(sgp_stds[:,0], lmp_stds.squeeze(), rtol=1e-3)
 
     os.chdir("..")


### PR DESCRIPTION
Fix the lammps variance when
- the training set contains isolated atoms
- the testing data contains isolated atoms

Add corresponding unit tests in the `test_lammps.py`